### PR TITLE
Issue with feedback assertion and the get_trace

### DIFF
--- a/optyx/core/channel.py
+++ b/optyx/core/channel.py
@@ -389,9 +389,10 @@ class Diagram(frobenius.Diagram):
                  mem: Ty,
                  initial_state: Diagram = None) -> Diagram:
         # check if mem, cod and dom are compatible
-        assert self.dom[-len(mem):] == self.cod[-len(mem):], (
+        assert self.dom[-len(mem):] == mem and self.cod[-len(mem):] == mem, (
             "The feedback types do not match. " +
-            f"Expected {self.dom[-len(mem):]}, got {self.cod[-len(mem):]}"
+            f"Expected dom and cod to end with {mem}, got "+
+            f"{self.dom[-len(mem):]}, and {self.cod[-len(mem):]}"
         )
 
         dom_stream = stream.Ty[Ty](

--- a/optyx/core/channel.py
+++ b/optyx/core/channel.py
@@ -389,9 +389,9 @@ class Diagram(frobenius.Diagram):
                  mem: Ty,
                  initial_state: Diagram = None) -> Diagram:
         # check if mem, cod and dom are compatible
-        assert self.dom[-len(mem):] == cod[-len(mem):], (
+        assert self.dom[-len(mem):] == self.cod[-len(mem):], (
             "The feedback types do not match. " +
-            f"Expected {self.dom[-len(mem):]}, got {cod[-len(mem):]}"
+            f"Expected {self.dom[-len(mem):]}, got {self.cod[-len(mem):]}"
         )
 
         dom_stream = stream.Ty[Ty](


### PR DESCRIPTION
Fix: feedback assertion reads the `cod` argument instead of `self.cod`

In `Diagram.feedback` (`optyx/core/channel.py:392`, `streams` branch):

```python
assert self.dom[-len(mem):] == cod[-len(mem):], (
    "The feedback types do not match. " +
    f"Expected {self.dom[-len(mem):]}, got {cod[-len(mem):]}"
)
```

The `self.` is missing on the right-hand side. Instead of comparing the diagram's codomain, it compares the domain against the `cod`.
The assertion does not work because requires the `cod` to end with the memory type. But `discopy.stream.Stream.feedback` (`stream.py:570`) asserts `self.cod.now == cod.now + mem.now` (so `cod` must not contain the memory. The two are contradictory because no value of `cod` satisfies both, unless the last wire of Y (codomain) happens to have the same type as M (Memory output).

```python
assert self.dom[-len(mem):] == mem and self.cod[-len(mem):] == mem, (
    "The feedback types do not match. " +
    f"Expected dom and cod to end with {mem}, got "+
    f"{self.dom[-len(mem):]}, and {self.cod[-len(mem):]}"
)
```