### PR TITLE
Fix the Streams branch

### DIFF
--- a/optyx/core/channel.py
+++ b/optyx/core/channel.py
@@ -389,9 +389,10 @@ class Diagram(frobenius.Diagram):
                  mem: Ty,
                  initial_state: Diagram = None) -> Diagram:
         # check if mem, cod and dom are compatible
-        assert self.dom[-len(mem):] == self.cod[-len(mem):], (
+        assert self.dom[-len(mem):] == mem and self.cod[-len(mem):] == mem, (
             "The feedback types do not match. " +
-            f"Expected {self.dom[-len(mem):]}, got {self.cod[-len(mem):]}"
+            f"Expected dom and cod to end with {mem}, got "+
+            f"{self.dom[-len(mem):]}, and {self.cod[-len(mem):]}"
         )
 
         dom_stream = stream.Ty[Ty](

--- a/optyx/core/channel.py
+++ b/optyx/core/channel.py
@@ -388,6 +388,11 @@ class Diagram(frobenius.Diagram):
                  cod: Ty,
                  mem: Ty,
                  initial_state: Diagram = None) -> Diagram:
+        # check if mem, cod and dom are compatible
+        assert self.dom[-len(mem):] == cod[-len(mem):], (
+            "The feedback types do not match. " +
+            f"Expected {self.dom[-len(mem):]}, got {cod[-len(mem):]}"
+        )
 
         dom_stream = stream.Ty[Ty](
             now=dom,
@@ -396,7 +401,7 @@ class Diagram(frobenius.Diagram):
         mem_stream = stream.Ty[Ty](mem)
 
         if initial_state is None:
-           f0 = self
+            f0 = self
         else:
             f0 = self << dom @ initial_state
         stream_diagram = stream.Stream[Diagram](
@@ -404,7 +409,7 @@ class Diagram(frobenius.Diagram):
             dom=dom_stream,
             cod=cod_stream,
             mem=stream.Ty[Ty](),
-            _later= lambda: stream.Stream[Diagram](self)
+            _later=lambda: stream.Stream[Diagram](self)
         )
 
         diagram = self._get_trace(n=len(mem))
@@ -458,12 +463,15 @@ class Diagram(frobenius.Diagram):
                 other_stream_diagram = other.feedback(
                     dom=other.dom, cod=other.cod, mem=Ty()
                 ).stream_diagram
-            result.stream_diagram = self_stream_diagram >> other_stream_diagram
+            result.stream_diagram = (
+                self_stream_diagram >>
+                other_stream_diagram
+            )
         return result
 
     def _get_trace(self, n=1):
         # check if cod[-n] matches dom[-n]
-        if n==0:
+        if n == 0:
             return self
         traced_dom = self.dom[-n:]
         cup = Id(traced_dom @ traced_dom)
@@ -471,32 +479,42 @@ class Diagram(frobenius.Diagram):
             cup = (
                 cup >>
                 (
-                    Id(self.dom[-n:-i]) @ Cup(self.dom[-i], self.dom[-i]) @
+                    Id(self.dom[-n:-i]) @
+                    Cup(self.dom[-i], self.dom[-i]) @
                     Id(self.dom[-n:-i][::-1])
                 )
             )
         traced_cod = self.cod[-n:]
         cap = Cap(traced_cod[-n], traced_cod[-n])
         for i in range(1, n):
-            cap = ( cap >>
+            cap = (
+                cap >>
                 (
-                    Id(self.dom[-n:-n+i]) @ Cap(self.cod[-n+i], self.cod[-n+i]) @
+                    Id(self.dom[-n:-n+i]) @
+                    Cap(self.cod[-n+i], self.cod[-n+i]) @
                     Id(self.dom[-n:-n+i][::-1])
                 )
             )
 
-        return self.dom[:-n] @ cap >> self @ self.dom[-n:][::-1] >> self.cod[:-n] @ cup
+        return (
+            self.dom[:-n] @ cap >>
+            self @ self.dom[-n:][::-1] >>
+            self.cod[:-n] @ cup
+        )
 
     @staticmethod
-    def delay(initial_state: Diagram) -> Diagram:
+    def delay(ty, initial_state: Diagram) -> Diagram:
         """
         Create a delay diagram with initial state.
 
         Parameters:
             initial_state : State to initialise the delay.
         """
-        return Swap(qmode, qmode).feedback(
-            dom=qmode, cod=qmode, mem=qmode, initial_state=initial_state)
+        from discopy.utils import assert_isatomic
+
+        assert_isatomic(ty), "Delay type must be atomic."
+        return Swap(ty, ty).feedback(
+            dom=ty, cod=ty, mem=ty, initial_state=initial_state)
 
     def to_dual_rail(self):
         """Convert to dual-rail encoding."""
@@ -816,6 +834,7 @@ class Spider(frobenius.Spider, Channel):  # pragma: no cover
             n_legs_in, n_legs_out, typ.single()
         )
         self.env = diagram.Ty()
+
 
 class Cup(frobenius.Cup, Channel):  # pragma: no cover
 

--- a/optyx/core/channel.py
+++ b/optyx/core/channel.py
@@ -389,9 +389,9 @@ class Diagram(frobenius.Diagram):
                  mem: Ty,
                  initial_state: Diagram = None) -> Diagram:
         # check if mem, cod and dom are compatible
-        assert self.dom[-len(mem):] == cod[-len(mem):], (
+        assert self.dom[-len(mem):] == self.cod[-len(mem):], (
             "The feedback types do not match. " +
-            f"Expected {self.dom[-len(mem):]}, got {cod[-len(mem):]}"
+            f"Expected {self.dom[-len(mem):]}, got {self.cod[-len(mem):]}"
         )
 
         dom_stream = stream.Ty[Ty](

--- a/optyx/core/channel.py
+++ b/optyx/core/channel.py
@@ -149,7 +149,7 @@ dual-rail encoding. For example, we can create a GHZ state:
 from __future__ import annotations
 
 from discopy import tensor
-from discopy import symmetric, frobenius, hypergraph
+from discopy import symmetric, frobenius, hypergraph, stream
 from discopy.cat import factory
 from pytket.extensions.pyzx import pyzx_to_tk
 from pyzx import extract_circuit
@@ -248,6 +248,8 @@ class Diagram(frobenius.Diagram):
 
     ty_factory = Ty
     grad = tensor.Diagram.grad
+    ob = Ty
+    _stream_diagram = None
 
     def needs_inflation(self) -> bool:
         """
@@ -380,6 +382,121 @@ class Diagram(frobenius.Diagram):
             ar=lambda arr: arr._decomp(),
             cod=frobenius.Category(Ty, Diagram),
         )(self)
+
+    def feedback(self,
+                 dom: Ty,
+                 cod: Ty,
+                 mem: Ty,
+                 initial_state: Diagram = None) -> Diagram:
+
+        dom_stream = stream.Ty[Ty](
+            now=dom,
+        )
+        cod_stream = stream.Ty[Ty](self.cod)
+        mem_stream = stream.Ty[Ty](mem)
+
+        if initial_state is None:
+           f0 = self
+        else:
+            f0 = self << dom @ initial_state
+        stream_diagram = stream.Stream[Diagram](
+            now=f0,
+            dom=dom_stream,
+            cod=cod_stream,
+            mem=stream.Ty[Ty](),
+            _later= lambda: stream.Stream[Diagram](self)
+        )
+
+        diagram = self._get_trace(n=len(mem))
+
+        diagram.stream_diagram = stream_diagram.feedback(
+            dom=stream.Ty[Ty](dom),
+            cod=stream.Ty[Ty](cod),
+            mem=mem_stream
+        )
+
+        return diagram
+
+    @property
+    def stream_diagram(self):
+        return self._stream_diagram
+
+    @stream_diagram.setter
+    def stream_diagram(self, value):
+        self._stream_diagram = value
+
+    def unroll(self, n: int) -> Diagram:
+        """
+        Unroll a feedback diagram for n steps.
+
+        Parameters:
+            n : Number of unrolling steps.
+        """
+        if self._stream_diagram is None:
+            self.stream_diagram = self.feedback(
+                dom=self.dom,
+                cod=self.cod,
+                mem=Ty()
+            ).stream_diagram
+        return self.stream_diagram.unroll(n).now
+
+    def then(self, other, *others):
+        result = super().then(other, *others)
+        if (
+            self._stream_diagram is not None or
+            other._stream_diagram is not None
+        ):
+            self_stream_diagram = self.stream_diagram
+            other_stream_diagram = other.stream_diagram
+
+            if self_stream_diagram is None:
+                self_stream_diagram = self.feedback(
+                    dom=self.dom, cod=self.cod, mem=Ty()
+                )
+
+            if other_stream_diagram is None:
+                other_stream_diagram = other.feedback(
+                    dom=other.dom, cod=other.cod, mem=Ty()
+                ).stream_diagram
+            result.stream_diagram = self_stream_diagram >> other_stream_diagram
+        return result
+
+    def _get_trace(self, n=1):
+        # check if cod[-n] matches dom[-n]
+        if n==0:
+            return self
+        traced_dom = self.dom[-n:]
+        cup = Id(traced_dom @ traced_dom)
+        for i in range(1, n+1):
+            cup = (
+                cup >>
+                (
+                    Id(self.dom[-n:-i]) @ Cup(self.dom[-i], self.dom[-i]) @
+                    Id(self.dom[-n:-i][::-1])
+                )
+            )
+        traced_cod = self.cod[-n:]
+        cap = Cap(traced_cod[-n], traced_cod[-n])
+        for i in range(1, n):
+            cap = ( cap >>
+                (
+                    Id(self.dom[-n:-n+i]) @ Cap(self.cod[-n+i], self.cod[-n+i]) @
+                    Id(self.dom[-n:-n+i][::-1])
+                )
+            )
+
+        return self.dom[:-n] @ cap >> self @ self.dom[-n:][::-1] >> self.cod[:-n] @ cup
+
+    @staticmethod
+    def delay(initial_state: Diagram) -> Diagram:
+        """
+        Create a delay diagram with initial state.
+
+        Parameters:
+            initial_state : State to initialise the delay.
+        """
+        return Swap(qmode, qmode).feedback(
+            dom=qmode, cod=qmode, mem=qmode, initial_state=initial_state)
 
     def to_dual_rail(self):
         """Convert to dual-rail encoding."""
@@ -571,6 +688,11 @@ class Diagram(frobenius.Diagram):
         if backend is None:
             backend = QuimbBackend()
 
+        if self._stream_diagram is not None:
+            raise ValueError(
+                "The diagram needs to be unrolled before evaluation."
+            )
+
         return backend.eval(self, **kwargs)
 
 
@@ -694,6 +816,17 @@ class Spider(frobenius.Spider, Channel):  # pragma: no cover
             n_legs_in, n_legs_out, typ.single()
         )
         self.env = diagram.Ty()
+
+class Cup(frobenius.Cup, Channel):  # pragma: no cover
+
+    ty_factory = Ty
+    __ambiguous_inheritance__ = (frobenius.Cup, Channel)
+
+
+class Cap(frobenius.Cap, Channel):  # pragma: no cover
+
+    ty_factory = Ty
+    __ambiguous_inheritance__ = (frobenius.Cap, Channel)
 
 
 class Sum(symmetric.Sum, Diagram):
@@ -945,3 +1078,4 @@ Diagram.spider_factory = Spider
 Diagram.hypergraph_factory = Hypergraph
 Diagram.braid_factory = Swap
 Diagram.sum_factory = Sum
+Diagram.ar = Diagram


### PR DESCRIPTION
Fix: feedback assertion reads the `cod` argument instead of `self.cod`

In `Diagram.feedback` (`optyx/core/channel.py:392`, `streams` branch):

```python
assert self.dom[-len(mem):] == cod[-len(mem):], (
    "The feedback types do not match. " +
    f"Expected {self.dom[-len(mem):]}, got {cod[-len(mem):]}"
)
```

The `self.` is missing on the right-hand side. Instead of comparing the diagram's codomain, it compares the domain against the `cod`.
The assertion does not work because requires the `cod` to end with the memory type. But `discopy.stream.Stream.feedback` (`stream.py:570`) asserts `self.cod.now == cod.now + mem.now` (so `cod` must not contain the memory. The two are contradictory because no value of `cod` satisfies both, unless the last wire of Y (codomain) happens to have the same type as M (Memory output).

```python
assert self.dom[-len(mem):] == mem and self.cod[-len(mem):] == mem, (
    "The feedback types do not match. " +
    f"Expected dom and cod to end with {mem}, got "+
    f"{self.dom[-len(mem):]}, and {self.cod[-len(mem):]}"
)
```